### PR TITLE
faster d1() calc

### DIFF
--- a/py_vollib/ref_python/black/__init__.py
+++ b/py_vollib/ref_python/black/__init__.py
@@ -73,7 +73,7 @@ def d1(F, K, t, r, sigma):  # keep r argument for consistency
     """
 
     sd = sigma * sqrt(t)
-    return numpy.log(F / float(K)) / sd + sd / 2.0
+    return log(F / float(K)) / sd + sd / 2.0
 
 
 def d2(F, K, t, r, sigma):  # keep r argument for consistency

--- a/py_vollib/ref_python/black/__init__.py
+++ b/py_vollib/ref_python/black/__init__.py
@@ -23,7 +23,6 @@ py_vollib.ref_python is a pure python version of py_vollib without any dependenc
 
 # Standard library imports
 from __future__ import division
-from math import log, sqrt
 
 # Related third party imports
 import numpy
@@ -73,11 +72,8 @@ def d1(F, K, t, r, sigma):  # keep r argument for consistency
     True
     """
 
-    sigma_squared = sigma * sigma
-    numerator = log(F / float(K)) + sigma_squared * t / 2.0
-    denominator = sigma * sqrt(t)
-
-    return numerator / denominator
+    sd = sigma * sqrt(t)
+    return numpy.log(F / float(K)) / sd + sd / 2.0
 
 
 def d2(F, K, t, r, sigma):  # keep r argument for consistency


### PR DESCRIPTION
On my computer, it's consistently 0.25 µs faster.

`3.84 µs ± 50.3 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)`

instead of 

`4.11 µs ± 15.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)`

And if you don't trust my math here's [wolfram](https://www.wolframalpha.com/input?i=%28log%28F%2FK%29+%2B+v%5E2+*+t+%2F+2%29+%2F+%28v+*+sqrt%28t%29%29)