### PR TITLE
fix: Update numpy and scipy dependencies to allow any version.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
+python = ">=3.9,<4"
 cody-special = "^1.0.0"
 piecewise-rational = "^1.0.0"
 py_lets_be_rational = "^1.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,13 @@ python = ">=3.9,<3.13"
 cody-special = "^1.0.0"
 piecewise-rational = "^1.0.0"
 py_lets_be_rational = "^1.0.1"
-simplejson = "^3.0"
-numpy = "^1.20"
-pandas = "^2.0"
-scipy = "^1.10"
+numpy = "*"
+scipy = "*"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.4,<9.0"
+simplejson = "*"
+pandas = "*"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Move dependencies to dev section, when they are only needed for tests.

All tests are passing -> `poetry run pytest tests/`

This will fix #32 